### PR TITLE
AddaxAI development support for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ config/*
 # anything in temp is not relevant
 assets/temp/*
 tmp/*
+
+# Do not check in micromamba binary on Linux
+bin/linux/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ config/*
 
 # anything in temp is not relevant
 assets/temp/*
+tmp/*

--- a/envs/ymls/addaxai-base/linux/environment.yml
+++ b/envs/ymls/addaxai-base/linux/environment.yml
@@ -1,0 +1,40 @@
+name: env-addaxai-base
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+    # Core Streamlit packages
+    - streamlit
+    - streamlit-extras
+    - streamlit-aggrid
+    
+    # Map and UI components
+    - folium
+    - streamlit-folium
+    - st-checkbox-tree
+    - streamlit-antd-components
+    - st-flexible-callout-elements
+    - streamlit-lottie
+    
+    # Image processing and metadata
+    - exifread
+    - piexif
+    - gpsphoto
+    - hachoir
+    
+    # Utility packages
+    - appdirs
+    - requests
+    - pillow
+    - tqdm
+    - huggingface_hub
+    - st-modal
+    - openpyxl
+    
+    # MegaDetector and detection packages
+    - megadetector==10.0.8
+    - ultralytics==8.3.177
+    # Note: speciesnet must be installed separately with --use-pep517 flag

--- a/envs/ymls/pytorch/linux/environment.yml
+++ b/envs/ymls/pytorch/linux/environment.yml
@@ -1,0 +1,18 @@
+name: env-pytorch
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+      - torch==2.0.1
+      - torchvision==0.15.2
+      - ultralytics==8.0.191
+      - numpy==1.24.1
+      - humanfriendly==10.0
+      - jsonpickle==3.0.2
+      - timm
+      - dill
+      - omegaconf
+      - pytorch-lightning==2.0.6
+      - albumentations==1.3.1

--- a/envs/ymls/tensorflow-v1/linux/environment.yml
+++ b/envs/ymls/tensorflow-v1/linux/environment.yml
@@ -1,0 +1,22 @@
+name: env-tensorflow-v1
+dependencies:
+  - python=3.8.15
+  - pip
+  - pip:
+    - humanfriendly
+    - imgaug
+    - jsonpickle
+    - keras_efficientnet_v2
+    - matplotlib
+    - numpy
+    - pandas
+    - piexif
+    - pillow
+    - pyyaml
+    - requests
+    - scikit-learn
+    - statistics
+    - tensorflow
+    - tensorflow-metal
+    - tensorflow_addons
+    - tqdm

--- a/envs/ymls/tensorflow-v2/linux/environment.yml
+++ b/envs/ymls/tensorflow-v2/linux/environment.yml
@@ -1,0 +1,24 @@
+name: env-tensorflow-v2
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+      - huggingface_hub==0.23.0
+      - jax==0.4.28
+      - jaxlib==0.4.28
+      - keras==3.3.3
+      - keras_cv==0.9.0
+      - kimm==0.2.5
+      - matplotlib==3.9.0
+      - numpy==1.26.4
+      - pandas==2.2.2
+      - pytest==8.3.0
+      - pyyaml==6.0.1
+      - scikit-learn==1.4.2
+      - tqdm==4.66.4
+      - jsonpickle==4.0.1
+      - opencv-python==4.11.0.86
+      - tensorflow-metal==1.1.0
+      - tensorflow-macos==2.16.2

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,14 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Tested on Fedora Linux
-# Not tested on macOS
+# ==============================================================================
+# Description: Sets up the local development environment for AddaxAI by
+#              installing micromamba, creating the base Python environment, and
+#              configuring platform-specific dependencies. Does not install
+#              model-specific Python environments, the user will be prompted to
+#              install these as required when using AddaxAI.
+#              Designed for both Linux and macOS, TODO: not yet tested on macOS.
+#
+# Usage:       ./bootstrap.sh
+#
+# System requirements:
+#   - curl
+#   - tar
+#
+# Notes:
+#   - Installs micromamba under ./bin/<os>/
+#   - Creates local envs under ./envs/
+#   - Uses local temp folder for Python caching, not the default /tmp
+#
+# ==============================================================================
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Error: '$1' is required but not installed." >&2
+        exit 1
+    fi
+}
+
+require curl
+require tar
 
 echo "Installing AddaxAI dependencies and configuring local environment"
 
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH=$(uname -m)
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -55,7 +82,8 @@ export PIP_CACHE_DIR="$TMP_LOCAL/pip_cache"
 
 echo "Creating Python environment..."
 ENV_PREFIX="$PROJECT_ROOT/envs/env-addaxai-base"
-$MICROMAMBA_BIN env create -f "$PROJECT_ROOT/envs/ymls/addaxai-base/macos/environment.yml" --prefix $ENV_PREFIX -y
+ENV_PATH_OS="${OS/darwin/macos}"
+$MICROMAMBA_BIN env create -f "$PROJECT_ROOT/envs/ymls/addaxai-base/$ENV_PATH_OS/environment.yml" --prefix $ENV_PREFIX -y
 
 SPECIESNET="speciesnet==5.0.2"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Tested on Fedora Linux
+# Not tested on macOS
+
 echo "Installing AddaxAI dependencies and configuring local environment"
 
 OS="$(uname | tr '[:upper:]' '[:lower:]')"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing AddaxAI dependencies and configuring local environment"
+
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+ARCH=$(uname -m)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+case "$OS" in
+    linux)
+        case "$ARCH" in
+            x86_64) MICROMAMBA_OS_ARCH="linux-64" ;;
+            aarch64|arm64) MICROMAMBA_OS_ARCH="linux-aarch64" ;;
+            ppc64le) MICROMAMBA_OS_ARCH="linux-ppc64le" ;;
+            *) echo "Unsupported Linux architecture: $ARCH"; exit 1 ;;
+        esac
+        ;;
+    darwin)
+        case "$ARCH" in
+            x86_64) MICROMAMBA_OS_ARCH="osx-64" ;;
+            arm64) MICROMAMBA_OS_ARCH="osx-arm64" ;;
+            *) echo "Unsupported macOS architecture: $ARCH"; exit 1 ;;
+        esac
+        ;;
+    *)
+        echo "Unsupported OS: $OS"; exit 1
+        ;;
+esac
+
+BIN_DIR="$PROJECT_ROOT/bin/$OS"
+mkdir -p $BIN_DIR
+
+MICROMAMBA_BIN="$BIN_DIR/micromamba"
+
+# This is the official way to install micromamba
+# https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html
+if [[ ! -f "$MICROMAMBA_BIN" ]]; then
+    echo "Downloading micromamba..."
+    curl -Ls "https://micro.mamba.pm/api/micromamba/$MICROMAMBA_OS_ARCH/latest" | tar -xvj -C "$BIN_DIR" --strip-components=1 bin/micromamba
+else
+    echo "Micromamba already installed at $MICROMAMBA_BIN"
+fi
+
+# Setting up python env may exceed /tmp on Linux, so use a local temp folder
+TMP_LOCAL="$PROJECT_ROOT/tmp"
+mkdir -p $TMP_LOCAL
+export TMPDIR=$TMP_LOCAL
+export PIP_CACHE_DIR="$TMP_LOCAL/pip_cache"
+
+echo "Creating Python environment..."
+ENV_PREFIX="$PROJECT_ROOT/envs/env-addaxai-base"
+$MICROMAMBA_BIN env create -f "$PROJECT_ROOT/envs/ymls/addaxai-base/macos/environment.yml" --prefix $ENV_PREFIX -y
+
+SPECIESNET="speciesnet==5.0.2"
+
+echo "Installing $SPECIESNET into $ENV_PREFIX..."
+
+if [[ "$OS" == "darwin" ]]; then
+    "$MICROMAMBA_BIN" run -p "$ENV_PREFIX" pip install --use-pep517 "$SPECIESNET"
+else
+    "$MICROMAMBA_BIN" run -p "$ENV_PREFIX" pip install "$SPECIESNET"
+fi
+
+echo "Done. You can now run AddaxAI with the following command:"
+echo "$MICROMAMBA_BIN run -p $ENV_PREFIX streamlit run main.py"

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Tearing down AddaxAI local environment..."
+
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BIN_DIR="$PROJECT_ROOT/bin/$OS"
+MICROMAMBA_BIN="$BIN_DIR/micromamba"
+ENV_PREFIX="$PROJECT_ROOT/envs/env-addaxai-base"
+TMP_LOCAL="$PROJECT_ROOT/tmp"
+
+echo "Removing micromamba binary (if any)..."
+rm -f "$MICROMAMBA_BIN"
+
+echo "Removing environment..."
+rm -rf "$ENV_PREFIX"
+
+echo "Removing temp directories..."
+rm -rf "$TMP_LOCAL"
+
+echo "Teardown complete."


### PR DESCRIPTION
# What this PR adds

- a script for developing AddaxAI on Linux, `scripts/bootstrap.sh`. It installs Python dependencies and configures the local environment to be able to serve AddaxAI from the repo folder.
- a script `scripts/teardown.sh` for reversing the effects of `bootstrap.sh`, so changes to `bootstrap.sh` can be tested

# Motivation

Prior to this pull request, streamlit-AddaxAI could only be developed on macOS, using a micromamba binary uploaded to the repo. For Linux development, I have chosen to install micromamba using an http request. The reasoning behind this:
- it is the installation method recommended by the micromamba maintainers
- avoids committing third party binaries to the repo
- requires no elevated privileges to install
- aligns with the platform-agnostic approach taken with streamlit-AddaxAI

I am open to a discussion around this approach, and I have not updated the README.md yet in recognition of the fact that a discussion may be required. 

# Versioning

The `bootstrap.sh` script currently installs the latest version of micromamba. It can easily be edited to pin to a specific version for later for reproducibility/ stability. I have not made the decision yet about which version to pin to.

# Testing

- `bootstrap.sh` has been run on Fedora Linux 42. There shouldn't be any distribution-specific commands.
- `bootstrap.sh` is designed to support macOS as well, though it has not been tested on macOS
- AddaxAI has been served and visited locally, website loads
- can create a project
- can install models using the GUI when the model is missing
- can NOT complete "Analyse new data" - encounters error:

```
FileNotFoundError: No taxonomy.csv found for model NZS-WEK-v1
```
